### PR TITLE
Feature/force fetch

### DIFF
--- a/demo/Examples.js
+++ b/demo/Examples.js
@@ -3,6 +3,7 @@ import { Route } from 'react-router-dom';
 import Basic from './examples/basic/index.js';
 import Dropdown from './examples/dropdown/index.js';
 import PageTransition from './examples/page-transition/index.js';
+import List from './examples/list/index.js';
 
 const Example = props => (
   <Route path={props.path} render={({ match }) => props.children()} />
@@ -13,6 +14,7 @@ const Examples = () => (
     <Example path="/basic">{() => <Basic />}</Example>
     <Example path="/dropdown">{() => <Dropdown />}</Example>
     <Example path="/page-transition">{() => <PageTransition />}</Example>
+    <Example path="/list">{() => <List />}</Example>
   </div>
 );
 

--- a/demo/Navigation.js
+++ b/demo/Navigation.js
@@ -17,7 +17,8 @@ const Navigation = () => (
   <ul>
     <NavigationLink to="/basic">Basic</NavigationLink>
     <NavigationLink to="/dropdown">Dropdown</NavigationLink>
-    <NavigationLink to="/page-transition">PageTransition</NavigationLink>
+    <NavigationLink to="/page-transition/a">PageTransition</NavigationLink>
+    <NavigationLink to="/list">List</NavigationLink>
   </ul>
 );
 

--- a/demo/examples/list/index.js
+++ b/demo/examples/list/index.js
@@ -1,0 +1,136 @@
+import React, { Component } from 'react';
+import ReactFlipContainer, {
+  BEFORE_ANIMATION,
+  ANIMATION
+} from '../../../src/ReactFlipContainer';
+import ReactFlipElement from '../../../src/ReactFlipElement';
+
+const List = props => <div>{props.children}</div>;
+const Item = ReactFlipElement()(
+  class Item extends Component {
+    render() {
+      let style = {
+        display: 'inline-block',
+        padding: '0.5em'
+      };
+      if (this.props.flip.status === BEFORE_ANIMATION && this.props.creating) {
+        style.position = 'absolute';
+        style.opacity = 0;
+        style.marginTop = -10;
+      } else if (this.props.flip.status === ANIMATION && this.props.deleting) {
+        style.position = 'absolute';
+        style.opacity = 0;
+        style.marginTop = 10;
+      }
+      return (
+        <div
+          style={style}
+          ref={this.props.flip.setFlipElement}
+          onClick={this.props.onClick}
+        >
+          {this.props.children}
+        </div>
+      );
+    }
+  }
+);
+
+class Dropdown extends Component {
+  constructor() {
+    super();
+    this.state = { list: [], createItem: null, removeItem: null };
+    this.reverse = this.reverse.bind(this);
+    this.add = this.add.bind(this);
+    this.sort = this.sort.bind(this);
+    this.cleanUp = this.cleanUp.bind(this);
+  }
+
+  shouldComponentUpdate(nextProps, nextState) {
+    return this.state !== nextState;
+  }
+
+  reverse() {
+    this.setState(state => ({
+      list: state.list.reverse()
+    }));
+  }
+
+  sort() {
+    this.setState(state => ({
+      list: state.list.sort((a, b) => a - b)
+    }));
+  }
+
+  add() {
+    this.setState(state => {
+      const index = Math.floor(state.list.length * Math.random());
+      const value = Math.ceil(Math.random() * 1000);
+      return {
+        list: [
+          ...state.list.slice(0, index),
+          value,
+          ...state.list.slice(index)
+        ],
+        createItem: value
+      };
+    });
+  }
+
+  remove(item) {
+    this.setState({
+      removeItem: item
+    });
+  }
+
+  cleanUp() {
+    this.setState(state => {
+      return {
+        createItem: null,
+        removeItem: null,
+        list: [...state.list.filter(value => value !== state.removeItem)]
+      };
+    });
+  }
+
+  isInteractive() {
+    return this.state.createItem === null && this.state.removeItem === null;
+  }
+
+  render() {
+    return (
+      <div>
+        <button onClick={this.isInteractive() && this.reverse}>
+          Reverse
+        </button>
+        <button onClick={this.isInteractive() && this.sort}>
+          Sort
+        </button>
+        <button onClick={this.isInteractive() && this.add}>
+          Add
+        </button>
+        <ReactFlipContainer
+          onAnimationEnd={this.cleanUp}
+          forceDefer={
+            this.state.createItem !== null || this.state.removeItem !== null
+          }
+          debug
+        >
+          <List>
+            {this.state.list.map(item => (
+              <Item
+                key={item}
+                creating={this.state.createItem === item}
+                deleting={this.state.removeItem === item}
+                onClick={this.isInteractive() && this.remove.bind(this, item)}
+              >
+                {item}
+              </Item>
+            ))}
+          </List>
+        </ReactFlipContainer>
+      </div>
+    );
+  }
+}
+
+export default Dropdown;

--- a/src/FlipGroup.js
+++ b/src/FlipGroup.js
@@ -1,7 +1,8 @@
 import Flip from './Flip';
 
 const not = fn => x => !fn(x);
-const isDeferred = element => element.defer;
+const isDeferred = element =>
+  typeof element.defer === 'function' ? element.defer() : element.defer;
 
 class FlipGroup {
   constructor() {

--- a/src/FlipGroup.test.js
+++ b/src/FlipGroup.test.js
@@ -26,6 +26,13 @@ describe('FlipGroup', () => {
     expect(group.elements.length).toBe(0);
   });
 
+  test('It should be possible to add a deferred Flip element using a function', () => {
+    const element = new Flip();
+    const group = new FlipGroup();
+    const remove = group.addElement(element, () => true);
+    expect(group.getConcernedElements(true).length).toBe(1);
+  });
+
   test('It should be possible to add a deferred Flip element', () => {
     const element = new Flip();
     const group = new FlipGroup();

--- a/src/FlipGroup.test.js
+++ b/src/FlipGroup.test.js
@@ -30,7 +30,7 @@ describe('FlipGroup', () => {
     const element = new Flip();
     const group = new FlipGroup();
     const remove = group.addElement(element, true);
-    expect(group.elementsDeferred.length).toBe(1);
+    expect(group.getConcernedElements(true).length).toBe(1);
   });
 
   test('It should be possible to remove a deferred Flip element', () => {
@@ -38,7 +38,7 @@ describe('FlipGroup', () => {
     const group = new FlipGroup();
     const remove = group.addElement(element, true);
     remove();
-    expect(group.elementsDeferred.length).toBe(0);
+    expect(group.getConcernedElements(true).length).toBe(0);
   });
 
   test('First method on a group should call it on children', () => {

--- a/src/ReactFlipContainer.js
+++ b/src/ReactFlipContainer.js
@@ -173,7 +173,10 @@ class ReactFlipContainer extends Component {
 
   onAnimationEnd() {
     return new Promise((resolve, reject) => {
-      this.setState({ animating: false, status: STATIC }, resolve);
+      this.setState({ animating: false, status: STATIC }, () => {
+        this.props.onAnimationEnd && this.props.onAnimationEnd();
+        resolve();
+      });
     });
   }
 

--- a/src/ReactFlipContainer.js
+++ b/src/ReactFlipContainer.js
@@ -51,8 +51,10 @@ class ReactFlipContainer extends Component {
 
   componentWillReceiveProps(nextProps) {
     if (shouldAnimate(nextProps) && this.props !== nextProps) {
-      if (nextProps.defer) {
-        this.first({ deferred: false });
+      if (nextProps.defer || nextProps.forceDefer) {
+        if (!nextProps.forceDefer) {
+          this.first({ deferred: false });
+        }
         this.setState({
           animating: false,
           preparingAnimation: true,
@@ -72,13 +74,17 @@ class ReactFlipContainer extends Component {
   componentDidUpdate(prevProps, prevState) {
     if (shouldAnimate(this.props)) {
       if (this.props !== prevProps) {
-        if (this.props.defer) {
-          // Set correct position of the undeferred elements
-          this.last({ deferred: false });
-          this.invert({ deferred: false });
+        if (this.props.defer || this.props.forceDefer) {
+          if (!this.props.forceDefer) {
+            // Set correct position of the undeferred elements
+            this.last({ deferred: false });
+            this.invert({ deferred: false });
 
-          // Set initial position of the deferred elements
-          this.first({ deferred: true });
+            // Set initial position of the deferred elements
+            this.first({ deferred: true });
+          } else {
+            this.first();
+          }
 
           // The animation will now begin on next update
           this.setState({
@@ -178,11 +184,13 @@ class ReactFlipContainer extends Component {
 
 ReactFlipContainer.propTypes = {
   defer: PropTypes.bool,
+  forceDefer: PropTypes.bool,
   children: PropTypes.node.isRequired
 };
 
 ReactFlipContainer.defaultProps = {
-  defer: false
+  defer: false,
+  forceDefer: false
 };
 
 ReactFlipContainer.childContextTypes = {

--- a/src/ReactFlipContainer.js
+++ b/src/ReactFlipContainer.js
@@ -43,18 +43,8 @@ class ReactFlipContainer extends Component {
     const flip = new Flip({ element, options, debug: this.props.debug });
 
     const defer = typeof options === 'function'
-      ? options().defer
+      ? () => options().defer
       : options.defer;
-
-    if (
-      process.env.NODE_ENV === 'development' &&
-      defer &&
-      this.props.defer === false
-    ) {
-      console.warn(
-        'ReactFlipContainer is not in defer mode while the ReactFlipElement is. This most likely will run unexpected behaviors. Make sure to update your container with the `defer` prop.'
-      );
-    }
 
     return this.flip.addElement(flip, defer);
   }

--- a/src/ReactFlipContainer.test.js
+++ b/src/ReactFlipContainer.test.js
@@ -276,6 +276,25 @@ describe('ReactFlipContainer', () => {
     });
   });
 
+  test('Should defer all elements when forceDefer option is used', () => {
+    FlipGroup.prototype.invert.mockImplementation(() => true);
+
+    const tree = mount(<Wrapper forceDefer />);
+    tree.instance().toggle();
+
+    expect({
+      first: FlipGroup.prototype.first.mock.calls,
+      last: FlipGroup.prototype.last.mock.calls,
+      invert: FlipGroup.prototype.invert.mock.calls,
+      play: FlipGroup.prototype.play.mock.calls
+    }).toEqual({
+      first: [[{ deferred: undefined }]],
+      last: [[{ deferred: undefined }]],
+      invert: [[{ deferred: undefined }]],
+      play: [[]]
+    });
+  });
+
   test('Should render back as static even with deferred elements', () => {
     let externalResolve;
     let removeMock = jest.fn();
@@ -356,5 +375,29 @@ describe('ReactFlipContainer', () => {
     );
     tree.unmount();
     expect(FlipGroup.prototype.addElement.mock.calls.length).toBe(0);
+  });
+
+  test('Should accept options in their function form and the resulting defer should be a function too', () => {
+    let externalResolve;
+
+    let optionMock = jest.fn();
+    optionMock.mockImplementation(() => ({
+      defer: true
+    }));
+
+    FlipGroup.prototype.addElement.mockImplementation((element, defer) => {
+      expect(defer()).toBe(true);
+    });
+
+    const DeferredElement = ReactFlipElement(optionMock)(props => {
+      return (
+        <div ref={props.flip.setFlipElement}>
+          Element
+        </div>
+      );
+    });
+
+    const tree = mount(<Wrapper defer Element={DeferredElement} />);
+    tree.instance().toggle();
   });
 });

--- a/src/ReactFlipContainer.test.js
+++ b/src/ReactFlipContainer.test.js
@@ -203,6 +203,30 @@ describe('ReactFlipContainer', () => {
     });
   });
 
+  test('Should call the animationEndCallback once the animation has ended', () => {
+    let externalResolve;
+    FlipGroup.prototype.invert.mockImplementation(() => true);
+    FlipGroup.prototype.play.mockImplementation(
+      () => new Promise(resolve => externalResolve = resolve)
+    );
+
+    const onAnimationEnd = jest.fn();
+
+    const tree = mount(<Wrapper onAnimationEnd={onAnimationEnd} />);
+    tree.instance().toggle();
+    externalResolve();
+
+    return new Promise(resolve => {
+      setTimeout(
+        () => {
+          expect(onAnimationEnd.mock.calls.length).toBe(1);
+          resolve();
+        },
+        0
+      );
+    });
+  });
+
   test('Should remove an element the FlipGroup on unmount', () => {
     const removeMock = jest.fn();
     FlipGroup.prototype.addElement.mockImplementation(() => removeMock);

--- a/src/ReactFlipElement.js
+++ b/src/ReactFlipElement.js
@@ -4,7 +4,7 @@ import ReactFlipContainer, { BEFORE_ANIMATION } from './ReactFlipContainer';
 const ReactFlipElement = (options = {}) =>
   BaseComponent => {
     const getOptions = props =>
-      typeof options === 'function' ? () => options(props) : options;
+      typeof options === 'function' ? () => options(props()) : options;
 
     class ReactFlipElement extends Component {
       constructor() {
@@ -40,7 +40,7 @@ const ReactFlipElement = (options = {}) =>
 
         return this.context.flip.registerElement({
           element: this.element,
-          options: getOptions(this.props)
+          options: getOptions(() => this.props)
         });
       }
 

--- a/src/__snapshots__/ReactFlipContainer.test.js.snap
+++ b/src/__snapshots__/ReactFlipContainer.test.js.snap
@@ -6,6 +6,7 @@ exports[`ReactFlipContainer Should animate if shouldAnimate is a function that r
 >
   <ReactFlipContainer
     defer={false}
+    forceDefer={false}
     shouldAnimate={[Function]}
   >
     <div>
@@ -37,6 +38,7 @@ exports[`ReactFlipContainer Should animate if shouldAnimate is true 1`] = `
 >
   <ReactFlipContainer
     defer={false}
+    forceDefer={false}
     shouldAnimate={true}
   >
     <div>
@@ -68,6 +70,7 @@ exports[`ReactFlipContainer Should not animate if shouldAnimate is a function th
 >
   <ReactFlipContainer
     defer={false}
+    forceDefer={false}
     shouldAnimate={[Function]}
   >
     <div>
@@ -99,6 +102,7 @@ exports[`ReactFlipContainer Should not animate if shouldAnimate is false 1`] = `
 >
   <ReactFlipContainer
     defer={false}
+    forceDefer={false}
     shouldAnimate={false}
   >
     <div>
@@ -128,6 +132,7 @@ exports[`ReactFlipContainer Should render as animating if play returned a promis
 <Wrapper>
   <ReactFlipContainer
     defer={false}
+    forceDefer={false}
   >
     <div>
       <ReactFlipElement
@@ -156,6 +161,7 @@ exports[`ReactFlipContainer Should render back as static if the play promise was
 <Wrapper>
   <ReactFlipContainer
     defer={false}
+    forceDefer={false}
   >
     <div>
       <ReactFlipElement


### PR DESCRIPTION
While creating a list of animatable components, I had to choose when to defer the animation and when not to.

Indeed, when you're just reordering components, you should not defer your components. However, if there is a new one or a deleted one, you have to.

In order to answer this, I added the `forceDefer` option to the `ReactFlipContainer`. It behaves as if you had all your `ReactFlipElement` having the options `{defer: true}`.